### PR TITLE
Resolve GitHub issue number 5

### DIFF
--- a/pkg/sql/optimizer/builder.go
+++ b/pkg/sql/optimizer/builder.go
@@ -49,11 +49,26 @@ func BuildPlanWithCTEs(stmt *parser.SelectStmt, catalog *schema.Catalog, ctes ma
 	hasAggregates := len(aggregates) > 0
 
 	if len(stmt.GroupBy) > 0 || hasAggregates {
+		// Extract SELECT expressions and aliases for proper output
+		var selectExprs []parser.Expression
+		var selectAliases []string
+		for _, col := range stmt.Columns {
+			if col.Star {
+				continue
+			}
+			if col.Expr != nil {
+				selectExprs = append(selectExprs, col.Expr)
+				selectAliases = append(selectAliases, col.Alias)
+			}
+		}
+
 		node = &AggregateNode{
-			Input:      node,
-			GroupBy:    stmt.GroupBy,
-			Aggregates: aggregates,
-			Having:     stmt.Having,
+			Input:         node,
+			GroupBy:       stmt.GroupBy,
+			Aggregates:    aggregates,
+			Having:        stmt.Having,
+			SelectExprs:   selectExprs,
+			SelectAliases: selectAliases,
 		}
 	}
 

--- a/pkg/sql/optimizer/plan.go
+++ b/pkg/sql/optimizer/plan.go
@@ -227,10 +227,12 @@ type AggregateExpr struct {
 
 // AggregateNode represents a GROUP BY operation with aggregations
 type AggregateNode struct {
-	Input      PlanNode            // Input plan (filtered data)
-	GroupBy    []parser.Expression // GROUP BY expressions (e.g., column refs)
-	Aggregates []AggregateExpr     // Aggregate functions to compute
-	Having     parser.Expression   // Optional HAVING filter (nil if none)
+	Input         PlanNode            // Input plan (filtered data)
+	GroupBy       []parser.Expression // GROUP BY expressions (e.g., column refs)
+	Aggregates    []AggregateExpr     // Aggregate functions to compute
+	Having        parser.Expression   // Optional HAVING filter (nil if none)
+	SelectExprs   []parser.Expression // Original SELECT column expressions (for proper output)
+	SelectAliases []string            // Aliases for SELECT columns
 }
 
 func (n *AggregateNode) EstimatedCost() float64 {


### PR DESCRIPTION
…nstead of COUNT

Fixes issue #5 where MIN() and MAX() aggregate functions were returning the row count instead of computing actual minimum and maximum values.

Root cause: The HashGroupByIterator's buildOutputRow() was only outputting COUNT(*) as a placeholder for all aggregate queries, ignoring the actual aggregate function requested.

Changes:
- Added SelectExprs and SelectAliases fields to AggregateNode to preserve the original SELECT column expressions
- Modified builder.go to populate these fields when building aggregate queries
- Updated HashGroupByIterator to compute per-expression aggregates based on the actual aggregate function and its arguments
- Modified buildOutputRow() to properly output MIN, MAX, SUM, AVG, and COUNT values based on the SELECT expressions
- Added comprehensive tests for MIN, MAX, SUM, AVG, and COUNT aggregates both with and without GROUP BY clauses